### PR TITLE
Add continue-on-error to Dev.to publish step

### DIFF
--- a/.github/workflows/devto-dev.yml
+++ b/.github/workflows/devto-dev.yml
@@ -38,7 +38,7 @@ jobs:
           separator: ","
           config: ./.github/.markdownlint.json
 
-      - name: Publish articles on dev.to
+      - name: Dry Run Publish to Dev.to
         uses: sinedied/publish-devto@v2
         with:
           files: 'posts/**/*.md'

--- a/.github/workflows/devto-dev.yml
+++ b/.github/workflows/devto-dev.yml
@@ -37,3 +37,11 @@ jobs:
           globs: ${{ steps.changed-files.outputs.all_changed_files }}
           separator: ","
           config: ./.github/.markdownlint.json
+
+      - name: Publish articles on dev.to
+        uses: sinedied/publish-devto@v2
+        with:
+          files: 'posts/**/*.md'
+          devto_key: ${{ secrets.DEVTO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true

--- a/.github/workflows/devto-main.yml
+++ b/.github/workflows/devto-main.yml
@@ -34,5 +34,4 @@ jobs:
           files: 'posts/**/*.md'
           devto_key: ${{ secrets.DEVTO_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          conventional_commits: false
-          dry_run: false
+        continue-on-error: true

--- a/posts/2025/DevAIOps-MCP-GitHub/DevAIOps-MCP-GitHub.md
+++ b/posts/2025/DevAIOps-MCP-GitHub/DevAIOps-MCP-GitHub.md
@@ -17,7 +17,7 @@ Enter the **Model Context Protocol (MCP)**. MCP is an open standard that allows 
 
 In this guide, we'll walk you through the process of setting up the **GitHub MCP server** in **VSCode** using **Node.js** (specifically npx), allowing you to supercharge your Copilot experience in Agent Mode. This setup will enable Copilot to interact directly with the GitHub API, allowing you to perform various actions like summarising or even creating issues, reading files, and searching code repositories directly from the chat interface.
 
-We will also cover the prerequisites, configuration steps, tips to ensure a smooth setup, and troubleshooting advice.
+We will also cover the prerequisites, configuration steps, tips to ensure a smooth setup, and troubleshooting advice
 
 ## Prerequisites
 


### PR DESCRIPTION
Ensure the Dev.to publish step uses `continue-on-error: true` so that workflows don’t fail when there are no changes to commit.