### PR TITLE
Fix dev (#175)

### DIFF
--- a/.github/.markdownlint.json
+++ b/.github/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": true,
   "MD013": false,
-  "MD051": false
-}
+  "MD051": false,
+  "MD033": false
+

--- a/.github/workflows/devto-dev.yml
+++ b/.github/workflows/devto-dev.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/devto-main.yml
+++ b/.github/workflows/devto-main.yml
@@ -7,16 +7,19 @@ on:
     paths:
       - 'posts/**/**.md'
       - 'posts/**/**/**.md'
+  # Allow manual runs from the Actions UI
+  workflow_dispatch: {}
 
 jobs:
 
   publishDevto:
-    # This job is triggered when a pull request to the main branch is merged.
-    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev' }}
+    # This job runs either when a qualifying PR is merged (existing behavior)
+    # or when the workflow is triggered manually from the Actions UI.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
   
@@ -26,7 +29,7 @@ jobs:
           node-version: 20
   
       - name: Install Dependencies
-        uses: bahmutov/npm-install@v1.10.9
+        uses: bahmutov/npm-install@v1.10.10
 
       - name: Publish articles on dev.to
         uses: sinedied/publish-devto@v2

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   },
   "dependencies": {
     "embedme": "1.22.1",
-    "prettier": "3.6.0"
+    "prettier": "3.6.2"
   }
 }

--- a/posts/2025/DevAIOps-Inst-GitHub/DevAIOps-Inst-GitHub.md
+++ b/posts/2025/DevAIOps-Inst-GitHub/DevAIOps-Inst-GitHub.md
@@ -1,12 +1,13 @@
 ---
 title: Instructions and Prompt Files to supercharge VS Code with GitHub Copilot
 published: true
-description: 'Unlock the power of GitHub Copilot in VS Code with Custom Instructions and Prompt Files.'
+description: Unlock the power of GitHub Copilot in VS Code with Custom Instructions and Prompt Files.
 tags: 'GitHubCopilot, MCP, tutorial, AI'
 cover_image: 'https://raw.githubusercontent.com/Pwd9000-ML/blog-devto/main/posts/2025/DevAIOps-Inst-GitHub/assets/main.png'
 canonical_url: null
 id: 2620657
 series: DevAIOps
+date: '2025-06-24T13:07:57Z'
 ---
 
 ## Supercharge Your GitHub Copilot: How DevOps Engineers are Mastering Customisation

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,10 +121,10 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-prettier@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.0.tgz#18ec98d62cb0757a5d4eab40253ff3e6d0fc8dea"
-  integrity sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==
+prettier@3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
+  integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
 
 supports-color@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
* chore: update published articles [skip ci]

* chore(deps): bump prettier from 3.6.0 to 3.6.2

Bumps [prettier](https://github.com/prettier/prettier) from 3.6.0 to 3.6.2.
- [Release notes](https://github.com/prettier/prettier/releases)
- [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
- [Commits](https://github.com/prettier/prettier/compare/3.6.0...3.6.2)

---
updated-dependencies:
- dependency-name: prettier dependency-version: 3.6.2 dependency-type: direct:production update-type: version-update:semver-patch ...



* chore(deps): bump actions/checkout from 4.2.2 to 5.0.0 (#172)

Bumps [actions/checkout](https://github.com/actions/checkout) from 4.2.2 to 5.0.0.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v4.2.2...v5.0.0)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-version: 5.0.0 dependency-type: direct:production update-type: version-update:semver-major ...




* fix: enable MD033 rule in markdownlint configuration

* chore(deps): bump bahmutov/npm-install from 1.10.9 to 1.10.10 (#173)

Bumps [bahmutov/npm-install](https://github.com/bahmutov/npm-install) from 1.10.9 to 1.10.10.
- [Release notes](https://github.com/bahmutov/npm-install/releases)
- [Commits](https://github.com/bahmutov/npm-install/compare/v1.10.9...v1.10.10)

---
updated-dependencies:
- dependency-name: bahmutov/npm-install dependency-version: 1.10.10 dependency-type: direct:production update-type: version-update:semver-patch ...




* feat: enable manual triggering of the publish workflow on Dev.to

---------